### PR TITLE
Add hotpotqa preprocessing and training script

### DIFF
--- a/examples/data_preprocess/hotpotqa_to_parquet.py
+++ b/examples/data_preprocess/hotpotqa_to_parquet.py
@@ -1,0 +1,94 @@
+"""Preprocess the HotpotQA dataset to parquet format."""
+
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import json
+import os
+import random
+from typing import Dict, List
+
+import pandas as pd
+from verl.utils.hdfs_io import copy, makedirs
+
+SRC_FILE = os.path.join(
+    "data",
+    "qa_dataset",
+    "train",
+    "hotpotqa_1000_20250402.json",
+)
+
+
+def load_examples(path: str) -> List[Dict]:
+    with open(path, "r") as f:
+        data = json.load(f)
+    return data.get("examples", [])
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--local_dir", default="~/data/hotpotqa")
+    parser.add_argument("--hdfs_dir", default=None)
+    args = parser.parse_args()
+
+    local_dir = os.path.expanduser(args.local_dir)
+    os.makedirs(local_dir, exist_ok=True)
+
+    examples = load_examples(SRC_FILE)
+    random.seed(42)
+    random.shuffle(examples)
+
+    split_idx = int(len(examples) * 0.8)
+    train_records = []
+    test_records = []
+
+    for idx, ex in enumerate(examples):
+        dataset_name = ex.get("dataset_name", "hotpotqa/hotpot_qa")
+        data_source_tagged = "searchR1_" + dataset_name.split("/")[0]
+
+        row = {
+            "data_source": data_source_tagged,
+            "prompt": [{"role": "user", "content": ex["question"]}],
+            "ability": "nlp",
+            "reward_model": {"style": "rule", "ground_truth": ex["answer"]},
+            "extra_info": {
+                "id": ex["id"],
+                "question": ex["question"],
+                "answer": ex["answer"],
+                "level": ex.get("level", ""),
+            },
+        }
+        if idx < split_idx:
+            row["extra_info"]["split"] = "train"
+            row["extra_info"]["index"] = idx
+            train_records.append(row)
+        else:
+            row["extra_info"]["split"] = "test"
+            row["extra_info"]["index"] = idx - split_idx
+            test_records.append(row)
+
+    train_df = pd.DataFrame(train_records)
+    test_df = pd.DataFrame(test_records)
+
+    train_df.to_parquet(os.path.join(local_dir, "train.parquet"))
+    test_df.to_parquet(os.path.join(local_dir, "test.parquet"))
+
+    if args.hdfs_dir is not None:
+        makedirs(args.hdfs_dir)
+        copy(src=local_dir, dst=args.hdfs_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/sglang_multiturn/run_qwen2.5-3b_hotpotqa_multiturn.sh
+++ b/examples/sglang_multiturn/run_qwen2.5-3b_hotpotqa_multiturn.sh
@@ -1,0 +1,54 @@
+# run on 8xH100
+# make sure your current working directory is the root of the project
+
+set -x
+
+ulimit -n 65535
+
+PROJECT_DIR="$(pwd)"
+CONFIG_PATH="$PROJECT_DIR/examples/sglang_multiturn/config"
+
+python3 -m verl.trainer.main_ppo \
+    --config-path="$CONFIG_PATH" \
+    --config-name='search_multiturn_grpo' \
+    algorithm.adv_estimator=grpo \
+    data.train_batch_size=256 \
+    data.max_prompt_length=1024 \
+    data.max_response_length=1024 \
+    data.filter_overlong_prompts=True \
+    data.truncation='error' \
+    data.return_raw_chat=True \
+    actor_rollout_ref.model.path=Qwen/Qwen2.5-3B-Instruct \
+    actor_rollout_ref.actor.optim.lr=1e-6 \
+    actor_rollout_ref.model.use_remove_padding=True \
+    actor_rollout_ref.actor.ppo_mini_batch_size=256 \
+    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=32 \
+    actor_rollout_ref.actor.use_kl_loss=True \
+    actor_rollout_ref.actor.kl_loss_coef=0.001 \
+    actor_rollout_ref.actor.kl_loss_type=low_var_kl \
+    actor_rollout_ref.actor.entropy_coeff=0 \
+    actor_rollout_ref.model.enable_gradient_checkpointing=True \
+    actor_rollout_ref.actor.fsdp_config.param_offload=False \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=False \
+    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=32 \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=2 \
+    actor_rollout_ref.rollout.name=sglang_async \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.5 \
+    actor_rollout_ref.rollout.n=16 \
+    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=32 \
+    actor_rollout_ref.ref.fsdp_config.param_offload=True \
+    algorithm.use_kl_in_reward=False \
+    trainer.critic_warmup=0 \
+    trainer.logger=['console','wandb'] \
+    trainer.project_name='hotpotqa_async_rl' \
+    trainer.experiment_name='qwen2.5-3b_function_rm-hotpotqa-async-sgl' \
+    trainer.n_gpus_per_node=8 \
+    trainer.nnodes=1 \
+    trainer.save_freq=-1 \
+    trainer.test_freq=20 \
+    data.train_files=$HOME/data/hotpotqa/train.parquet \
+    data.val_files=$HOME/data/hotpotqa/test.parquet \
+    custom_reward_function.path="verl/utils/reward_score/search_r1_like_qa_em.py" \
+    custom_reward_function.name=compute_score \
+    actor_rollout_ref.rollout.multi_turn.tool_config_path="$PROJECT_DIR/examples/sglang_multiturn/config/tool_config/search_tool_config.yaml" \
+    trainer.total_epochs=15 "$@"


### PR DESCRIPTION
## Summary
- enhance `hotpotqa_to_parquet.py` to support configurable output directory and tagging for Search-R1 reward
- add `run_qwen2.5-3b_hotpotqa_multiturn.sh` for multi-turn training on HotpotQA with the Search-R1 reward function

## Testing
- `ruff check examples/data_preprocess/hotpotqa_to_parquet.py`
- `ruff check examples/sglang_multiturn/run_qwen2.5-3b_hotpotqa_multiturn.sh`

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_683bfa32cd44832da29a8f70df1bbe8d