### PR TITLE
Add thinking-aware reward handling

### DIFF
--- a/verl/workers/reward_manager/naive.py
+++ b/verl/workers/reward_manager/naive.py
@@ -76,7 +76,7 @@ class NaiveRewardManager:
             )
 
             if isinstance(score, dict):
-                reward = score["score"]
+                reward = score.get("reward", score.get("score"))
                 # Store the information including original reward
                 for key, value in score.items():
                     reward_extra_info[key].append(value)


### PR DESCRIPTION
## Summary
- add thinking tag counters and update search_r1_like reward computation
- include accuracy and reward separately
- handle `reward` key in naive reward manager

## Testing
- `pytest tests/trainer/ppo/test_metric_utils.py::TestProcessValidationMetrics::test_process_validation_metrics_basic -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6848ac5d2684832d9345a6efe23723c0