### PR TITLE
Add thinking-aware reward handling

### DIFF
--- a/recipe/spin/spin_trainer.py
+++ b/recipe/spin/spin_trainer.py
@@ -683,10 +683,13 @@ class RaySPINTrainer:
             scores = reward_tensor.sum(-1).cpu().tolist()
             sample_scores.extend(scores)
 
-            reward_extra_infos_dict["reward"].extend(scores)
             if "reward_extra_info" in result:
                 for key, lst in result["reward_extra_info"].items():
                     reward_extra_infos_dict[key].extend(lst)
+                if "reward" not in result["reward_extra_info"]:
+                    reward_extra_infos_dict["reward"].extend(scores)
+            else:
+                reward_extra_infos_dict["reward"].extend(scores)
 
             data_source_lst.append(test_batch.non_tensor_batch.get("data_source", ["unknown"] * reward_tensor.shape[0]))
 

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -704,10 +704,14 @@ class RayPPOTrainer:
             scores = reward_tensor.sum(-1).cpu().tolist()
             sample_scores.extend(scores)
 
-            reward_extra_infos_dict["reward"].extend(scores)
             if "reward_extra_info" in result:
                 for key, lst in result["reward_extra_info"].items():
                     reward_extra_infos_dict[key].extend(lst)
+                if "reward" not in result["reward_extra_info"]:
+                    reward_extra_infos_dict["reward"].extend(scores)
+            else:
+                reward_extra_infos_dict["reward"].extend(scores)
+
 
             data_source_lst.append(test_batch.non_tensor_batch.get("data_source", ["unknown"] * reward_tensor.shape[0]))
 

--- a/verl/workers/reward_manager/naive.py
+++ b/verl/workers/reward_manager/naive.py
@@ -76,7 +76,7 @@ class NaiveRewardManager:
             )
 
             if isinstance(score, dict):
-                reward = score["score"]
+                reward = score.get("reward", score.get("score"))
                 # Store the information including original reward
                 for key, value in score.items():
                     reward_extra_info[key].append(value)


### PR DESCRIPTION
## Summary
- add thinking tag counters and update search_r1_like reward computation
- include accuracy and reward separately
- handle `reward` key in naive reward manager
- avoid duplicating reward entries during validation

## Testing
- `pytest tests/trainer/ppo/test_metric_utils.py::TestProcessValidationMetrics::test_process_validation_metrics_basic -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6848ac5d2684832d9345a6efe23723c0